### PR TITLE
feat: add AccountantProxy for controlled vault self-reporting

### DIFF
--- a/script/DeployAccountantProxy.s.sol
+++ b/script/DeployAccountantProxy.s.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.23;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+import {AccountantProxy} from "../src/AccountantProxy.sol";
+
+contract DeployAccountantProxy is Script {
+    address public governance = 0xBe7c7efc1ef3245d37E3157F76A512108D6D7aE6;
+    address public accountant = 0x1f399808fE52d0E960CAB84b6b54d5707ab27c8a; 
+
+    function run() public {
+        vm.startBroadcast();
+
+        AccountantProxy accountantProxy = new AccountantProxy(accountant, governance);
+        console.log("AccountantProxy deployed to:", address(accountantProxy));
+
+        vm.stopBroadcast();
+    }
+}

--- a/src/AccountantProxy.sol
+++ b/src/AccountantProxy.sol
@@ -27,7 +27,10 @@ contract AccountantProxy is Governance {
     mapping(address => bool) public canReport;
 
     modifier onlyReporter() {
-        require(canReport[msg.sender] || msg.sender == governance, "!authorized");
+        require(
+            canReport[msg.sender] || msg.sender == governance,
+            "!authorized"
+        );
         _;
     }
 

--- a/src/AccountantProxy.sol
+++ b/src/AccountantProxy.sol
@@ -27,7 +27,7 @@ contract AccountantProxy is Governance {
     mapping(address => bool) public canReport;
 
     modifier onlyReporter() {
-        require(canReport[msg.sender], "!authorized");
+        require(canReport[msg.sender] || msg.sender == governance, "!authorized");
         _;
     }
 

--- a/src/AccountantProxy.sol
+++ b/src/AccountantProxy.sol
@@ -73,9 +73,9 @@ contract AccountantProxy is Governance {
 
         // Post-report sanity checks
         require(gain == expectedGain, "gain mismatch");
-        // Verify PPS hasn't increased (allowing for rounding)
+        // Verify PPS hasn't increased
         require(IVault(vault).pricePerShare() == prePPS, "PPS changed");
-        // Account for fees reducing the idle increase
+        // Total idle should have increased by the expected gain
         require(
             IVault(vault).totalIdle() == preTotalIdle + expectedGain,
             "Idle update incorrect"

--- a/src/AccountantProxy.sol
+++ b/src/AccountantProxy.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.18;
+
+import {Governance} from "@periphery/utils/Governance.sol";
+import {IVault} from "@yearn-vaults/interfaces/IVault.sol";
+
+interface IAccountant {
+    function turnOffHealthCheck(address vault, address strategy) external;
+}
+
+interface IERC20 {
+    function balanceOf(address account) external view returns (uint256);
+}
+
+/**
+ * @title AccountantProxy
+ * @notice Proxy contract that wraps an Accountant to allow authorized addresses to trigger self-reporting
+ * @dev Acts as a pass-through for all other accountant functions while adding self-reporting capability
+ */
+contract AccountantProxy is Governance {
+    // Events
+    event ReporterSet(address indexed reporter, bool authorized);
+
+    // State variables
+    address public immutable ACCOUNTANT;
+
+    mapping(address => bool) public canReport;
+
+    modifier onlyReporter() {
+        require(canReport[msg.sender], "!authorized");
+        _;
+    }
+
+    /**
+     * @notice Constructor to set the accountant address and governance
+     * @param _accountant Address of the underlying accountant contract
+     * @param _governance Address of the governance
+     */
+    constructor(
+        address _accountant,
+        address _governance
+    ) Governance(_governance) {
+        require(_accountant != address(0), "zero address");
+        ACCOUNTANT = _accountant;
+    }
+
+    /**
+     * @notice Allows authorized addresses to trigger self-reporting for a vault
+     * @param vault Address of the vault to report on itself
+     * @return gain Amount of gain reported
+     * @return loss Amount of loss reported
+     */
+    function reportOnSelf(
+        address vault
+    ) external onlyReporter returns (uint256 gain, uint256 loss) {
+        // Store pre-report state
+        uint256 preTotalAssets = IVault(vault).totalAssets();
+        uint256 preTotalIdle = IVault(vault).totalIdle();
+        uint256 prePPS = IVault(vault).pricePerShare();
+
+        // Get the actual asset balance to determine expected gain
+        address asset = IVault(vault).asset();
+        uint256 vaultAssetBalance = IERC20(asset).balanceOf(vault);
+        uint256 expectedGain = vaultAssetBalance - preTotalIdle;
+
+        require(expectedGain > 0, "no gain");
+
+        // Turn off health check for self-reporting
+        IAccountant(ACCOUNTANT).turnOffHealthCheck(vault, vault);
+
+        // Trigger the vault to report on itself
+        (gain, loss) = IVault(vault).process_report(vault);
+
+        // Post-report sanity checks
+        require(gain == expectedGain, "gain mismatch");
+        // Verify PPS hasn't increased (allowing for rounding)
+        require(IVault(vault).pricePerShare() == prePPS, "PPS changed");
+        // Account for fees reducing the idle increase
+        require(
+            IVault(vault).totalIdle() == preTotalIdle + expectedGain,
+            "Idle update incorrect"
+        );
+
+        // Verify total assets changed as expected
+        require(
+            IVault(vault).totalAssets() == preTotalAssets + expectedGain,
+            "Total assets mismatch"
+        );
+        require(loss == 0, "loss is not 0");
+
+        return (gain, loss);
+    }
+
+    /**
+     * @notice Set or remove reporter authorization for an address
+     * @param reporter Address to set authorization for
+     * @param authorized Whether the address should be authorized
+     */
+    function setReporter(
+        address reporter,
+        bool authorized
+    ) external onlyGovernance {
+        require(reporter != address(0), "zero address");
+        require(canReport[reporter] != authorized, "already set");
+
+        canReport[reporter] = authorized;
+
+        emit ReporterSet(reporter, authorized);
+    }
+
+    /**
+     * @notice Fallback function to forward all other calls to the accountant
+     * @dev Validates permissions based on function selector before forwarding
+     */
+    fallback() external payable {
+        _checkGovernance();
+
+        address _accountant = ACCOUNTANT;
+
+        assembly {
+            // Copy calldata to memory
+            let ptr := mload(0x40)
+            calldatacopy(ptr, 0, calldatasize())
+
+            // Forward call to accountant
+            let result := call(
+                gas(),
+                _accountant,
+                callvalue(),
+                ptr,
+                calldatasize(),
+                0,
+                0
+            )
+
+            // Copy return data
+            let size := returndatasize()
+            returndatacopy(ptr, 0, size)
+
+            // Return or revert based on result
+            switch result
+            case 0 {
+                revert(ptr, size)
+            }
+            default {
+                return(ptr, size)
+            }
+        }
+    }
+
+    /**
+     * @notice Receive function to handle plain ETH transfers
+     * @dev Reverts as this contract should not hold ETH
+     */
+    receive() external payable {
+        revert("No ETH accepted");
+    }
+}

--- a/src/AccountantProxy.sol
+++ b/src/AccountantProxy.sol
@@ -112,47 +112,19 @@ contract AccountantProxy is Governance {
      * @notice Fallback function to forward all other calls to the accountant
      * @dev Validates permissions based on function selector before forwarding
      */
-    fallback() external payable {
+    fallback() external {
         _checkGovernance();
 
-        address _accountant = ACCOUNTANT;
+        (bool success, bytes memory result) = ACCOUNTANT.call(msg.data);
 
-        assembly {
-            // Copy calldata to memory
-            let ptr := mload(0x40)
-            calldatacopy(ptr, 0, calldatasize())
-
-            // Forward call to accountant
-            let result := call(
-                gas(),
-                _accountant,
-                callvalue(),
-                ptr,
-                calldatasize(),
-                0,
-                0
-            )
-
-            // Copy return data
-            let size := returndatasize()
-            returndatacopy(ptr, 0, size)
-
-            // Return or revert based on result
-            switch result
-            case 0 {
-                revert(ptr, size)
+        if (success) {
+            assembly {
+                return(add(result, 0x20), mload(result))
             }
-            default {
-                return(ptr, size)
+        } else {
+            assembly {
+                revert(add(result, 0x20), mload(result))
             }
         }
-    }
-
-    /**
-     * @notice Receive function to handle plain ETH transfers
-     * @dev Reverts as this contract should not hold ETH
-     */
-    receive() external payable {
-        revert("No ETH accepted");
     }
 }

--- a/src/test/AccountantProxy.t.sol
+++ b/src/test/AccountantProxy.t.sol
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.18;
+
+import {Setup, ERC20, IVault} from "./utils/Setup.sol";
+import {AccountantProxy} from "../AccountantProxy.sol";
+
+interface IAccountantFull {
+    function turnOffHealthCheck(address vault, address strategy) external;
+    function addVault(address vault) external;
+    function setFeeRecipient(address newFeeRecipient) external;
+    function feeManager() external view returns (address);
+    function feeRecipient() external view returns (address);
+    function vaultManager() external view returns (address);
+    function setFutureFeeManager(address _futureFeeManager) external;
+    function acceptFeeManager() external;
+    function updateDefaultConfig(
+        uint16 defaultManagement,
+        uint16 defaultPerformance,
+        uint16 defaultRefund,
+        uint16 defaultMaxFee,
+        uint16 defaultMaxGain,
+        uint16 defaultMaxLoss
+    ) external;
+}
+
+interface IAccountantFactory {
+    function newAccountant(
+        address feeManager,
+        address feeRecipient
+    ) external returns (address);
+}
+
+contract AccountantProxyTest is Setup {
+    event ReporterSet(address indexed reporter, bool authorized);
+
+    AccountantProxy public accountantProxy;
+    IAccountantFull public accountant;
+    address public reporter = address(0x1234);
+    address public nonReporter = address(0x5678);
+    address constant ACCOUNTANT_FACTORY =
+        0xF728f839796a399ACc2823c1e5591F05a31c32d1;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        // Deploy a new accountant from the factory
+        // AccountantProxy will be the fee manager, management will be the fee recipient
+        address newAccountant = IAccountantFactory(ACCOUNTANT_FACTORY)
+            .newAccountant(
+                management, // fee manager (temporary, will transfer to proxy)
+                management // fee recipient
+            );
+        accountant = IAccountantFull(newAccountant);
+
+        // Deploy AccountantProxy with management as governance
+        accountantProxy = new AccountantProxy(address(accountant), management);
+
+        // Transfer fee manager role to the proxy
+        vm.prank(management); // management is the initial fee manager
+        accountant.setFutureFeeManager(address(accountantProxy));
+
+        vm.prank(address(accountantProxy));
+        accountant.acceptFeeManager();
+
+        // Add the preDepositVault to the accountant
+        vm.prank(management);
+        IAccountantFull(address(accountantProxy)).addVault(
+            address(preDepositVault)
+        );
+
+        // Set the new accountant on the vault
+        vm.prank(chad);
+        preDepositVault.set_accountant(address(accountant));
+
+        // Give the accountant proxy permission to report
+        vm.prank(address(yearnRoleManager));
+        preDepositVault.add_role(address(accountantProxy), 32); // REPORTING_MANAGER role = 32
+    }
+
+    function test_constructor() public {
+        assertEq(accountantProxy.ACCOUNTANT(), address(accountant));
+        assertEq(accountantProxy.governance(), management);
+    }
+
+    function test_setReporter() public {
+        // Test adding a reporter
+        vm.expectEmit(true, false, false, true);
+        emit ReporterSet(reporter, true);
+
+        vm.prank(management);
+        accountantProxy.setReporter(reporter, true);
+
+        assertTrue(accountantProxy.canReport(reporter));
+
+        // Test removing a reporter
+        vm.expectEmit(true, false, false, true);
+        emit ReporterSet(reporter, false);
+
+        vm.prank(management);
+        accountantProxy.setReporter(reporter, false);
+
+        assertFalse(accountantProxy.canReport(reporter));
+    }
+
+    function test_setReporter_revertConditions() public {
+        // Test zero address
+        vm.prank(management);
+        vm.expectRevert("zero address");
+        accountantProxy.setReporter(address(0), true);
+
+        // Test already set
+        vm.prank(management);
+        accountantProxy.setReporter(reporter, true);
+
+        vm.prank(management);
+        vm.expectRevert("already set");
+        accountantProxy.setReporter(reporter, true);
+
+        // Test non-governance
+        vm.expectRevert("!governance");
+        accountantProxy.setReporter(reporter, false);
+    }
+
+    function test_reportOnSelf() public {
+        // Setup: Add reporter and airdrop tokens to vault
+        vm.prank(management);
+        accountantProxy.setReporter(reporter, true);
+
+        uint256 airdropAmount = 1000 * 10 ** decimals;
+
+        // Airdrop tokens directly to the vault
+        airdrop(asset, address(preDepositVault), airdropAmount);
+
+        // Store initial state
+        uint256 initialTotalAssets = preDepositVault.totalAssets();
+        uint256 initialTotalIdle = preDepositVault.totalIdle();
+        uint256 initialPPS = preDepositVault.pricePerShare();
+
+        // Report on self
+        vm.prank(reporter);
+        (uint256 gain, uint256 loss) = accountantProxy.reportOnSelf(
+            address(preDepositVault)
+        );
+
+        // Verify results
+        assertEq(gain, airdropAmount, "gain should equal airdrop amount");
+        assertEq(loss, 0, "loss should be 0");
+        assertEq(
+            preDepositVault.pricePerShare(),
+            initialPPS,
+            "PPS should not change"
+        );
+        assertEq(
+            preDepositVault.totalIdle(),
+            initialTotalIdle + airdropAmount,
+            "totalIdle should increase by gain"
+        );
+        assertEq(
+            preDepositVault.totalAssets(),
+            initialTotalAssets + airdropAmount,
+            "totalAssets should increase by gain"
+        );
+    }
+
+    function test_reportOnSelf_revertNoGain() public {
+        vm.prank(management);
+        accountantProxy.setReporter(reporter, true);
+
+        // Try to report when there's no gain
+        vm.prank(reporter);
+        vm.expectRevert("no gain");
+        accountantProxy.reportOnSelf(address(preDepositVault));
+    }
+
+    function test_reportOnSelf_revertUnauthorized() public {
+        // Try to report without being authorized
+        vm.expectRevert("!authorized");
+        accountantProxy.reportOnSelf(address(preDepositVault));
+    }
+
+    function test_fallback_governance() public {
+        // Test that governance can call fee manager functions through fallback
+        address newFeeRecipient = address(0x9999);
+
+        vm.prank(management);
+        IAccountantFull(address(accountantProxy)).setFeeRecipient(
+            newFeeRecipient
+        );
+
+        assertEq(
+            IAccountantFull(address(accountant)).feeRecipient(),
+            newFeeRecipient,
+            "fee recipient should be updated"
+        );
+    }
+
+    function test_fallback_revertNonGovernance() public {
+        // Test that non-governance cannot call through fallback
+        vm.expectRevert("!governance");
+        IAccountantFull(address(accountantProxy)).setFeeRecipient(
+            address(0x9999)
+        );
+    }
+
+    function test_fallback_updateDefaultConfig() public {
+        // Test updating default config through fallback
+        vm.prank(management);
+        IAccountantFull(address(accountantProxy)).updateDefaultConfig(
+            100, // management fee (1%)
+            1000, // performance fee (10%)
+            0, // refund ratio
+            5000, // max fee (50%)
+            10000, // max gain (100%)
+            10000 // max loss (100%)
+        );
+    }
+
+    function test_receiveReverts() public {
+        // Test that the contract reverts on ETH transfers
+        vm.deal(address(this), 1 ether);
+        vm.expectRevert("No ETH accepted");
+        payable(address(accountantProxy)).transfer(1 ether);
+    }
+
+    function test_reportOnSelf_withFuzzedAmount(uint256 _amount) public {
+        vm.assume(_amount > minFuzzAmount && _amount < maxFuzzAmount);
+
+        // Setup reporter
+        vm.prank(management);
+        accountantProxy.setReporter(reporter, true);
+
+        // Airdrop tokens to vault
+        airdrop(asset, address(preDepositVault), _amount);
+
+        // Store initial state
+        uint256 initialPPS = preDepositVault.pricePerShare();
+
+        // Report on self
+        vm.prank(reporter);
+        (uint256 gain, uint256 loss) = accountantProxy.reportOnSelf(
+            address(preDepositVault)
+        );
+
+        // Verify
+        assertEq(gain, _amount);
+        assertEq(loss, 0);
+        assertEq(preDepositVault.pricePerShare(), initialPPS);
+    }
+
+    function test_multipleReporters() public {
+        address reporter2 = address(0x2222);
+        address reporter3 = address(0x3333);
+
+        // Add multiple reporters
+        vm.startPrank(management);
+        accountantProxy.setReporter(reporter, true);
+        accountantProxy.setReporter(reporter2, true);
+        accountantProxy.setReporter(reporter3, true);
+        vm.stopPrank();
+
+        // Verify all can report
+        assertTrue(accountantProxy.canReport(reporter));
+        assertTrue(accountantProxy.canReport(reporter2));
+        assertTrue(accountantProxy.canReport(reporter3));
+
+        // Remove one
+        vm.prank(management);
+        accountantProxy.setReporter(reporter2, false);
+
+        // Verify removal
+        assertTrue(accountantProxy.canReport(reporter));
+        assertFalse(accountantProxy.canReport(reporter2));
+        assertTrue(accountantProxy.canReport(reporter3));
+    }
+
+    function test_governanceTransfer() public {
+        address newGovernance = address(0x7777);
+
+        // Transfer governance
+        vm.prank(management);
+        accountantProxy.transferGovernance(newGovernance);
+
+        assertEq(accountantProxy.governance(), newGovernance);
+
+        // Old governance cannot call functions
+        vm.prank(management);
+        vm.expectRevert("!governance");
+        accountantProxy.setReporter(reporter, true);
+
+        // New governance can
+        vm.prank(newGovernance);
+        accountantProxy.setReporter(reporter, true);
+        assertTrue(accountantProxy.canReport(reporter));
+    }
+
+    function test_reportOnSelf_sanityChecks() public {
+        vm.prank(management);
+        accountantProxy.setReporter(reporter, true);
+
+        uint256 airdropAmount = 5000 * 10 ** decimals;
+
+        // Setup: Create a scenario where we have airdropped tokens
+        airdrop(asset, address(preDepositVault), airdropAmount);
+
+        uint256 preTotalAssets = preDepositVault.totalAssets();
+        uint256 preTotalIdle = preDepositVault.totalIdle();
+        uint256 prePPS = preDepositVault.pricePerShare();
+
+        // Execute report
+        vm.prank(reporter);
+        (uint256 gain, uint256 loss) = accountantProxy.reportOnSelf(
+            address(preDepositVault)
+        );
+
+        // All sanity checks should pass
+        assertEq(gain, airdropAmount, "gain mismatch");
+        assertEq(loss, 0, "loss should be 0");
+        assertEq(
+            preDepositVault.pricePerShare(),
+            prePPS,
+            "PPS should not change"
+        );
+        assertEq(
+            preDepositVault.totalIdle(),
+            preTotalIdle + airdropAmount,
+            "idle mismatch"
+        );
+        assertEq(
+            preDepositVault.totalAssets(),
+            preTotalAssets + airdropAmount,
+            "assets mismatch"
+        );
+    }
+}

--- a/src/test/AccountantProxy.t.sol
+++ b/src/test/AccountantProxy.t.sol
@@ -59,8 +59,8 @@ contract AccountantProxyTest is Setup {
         vm.prank(management); // management is the initial fee manager
         accountant.setFutureFeeManager(address(accountantProxy));
 
-        vm.prank(address(accountantProxy));
-        accountant.acceptFeeManager();
+        vm.prank(address(management));
+        IAccountantFull(address(accountantProxy)).acceptFeeManager();
 
         // Add the preDepositVault to the accountant
         vm.prank(management);
@@ -284,44 +284,5 @@ contract AccountantProxyTest is Setup {
         vm.prank(newGovernance);
         accountantProxy.setReporter(reporter, true);
         assertTrue(accountantProxy.canReport(reporter));
-    }
-
-    function test_reportOnSelf_sanityChecks() public {
-        vm.prank(management);
-        accountantProxy.setReporter(reporter, true);
-
-        uint256 airdropAmount = 5000 * 10 ** decimals;
-
-        // Setup: Create a scenario where we have airdropped tokens
-        airdrop(asset, address(preDepositVault), airdropAmount);
-
-        uint256 preTotalAssets = preDepositVault.totalAssets();
-        uint256 preTotalIdle = preDepositVault.totalIdle();
-        uint256 prePPS = preDepositVault.pricePerShare();
-
-        // Execute report
-        vm.prank(reporter);
-        (uint256 gain, uint256 loss) = accountantProxy.reportOnSelf(
-            address(preDepositVault)
-        );
-
-        // All sanity checks should pass
-        assertEq(gain, airdropAmount, "gain mismatch");
-        assertEq(loss, 0, "loss should be 0");
-        assertEq(
-            preDepositVault.pricePerShare(),
-            prePPS,
-            "PPS should not change"
-        );
-        assertEq(
-            preDepositVault.totalIdle(),
-            preTotalIdle + airdropAmount,
-            "idle mismatch"
-        );
-        assertEq(
-            preDepositVault.totalAssets(),
-            preTotalAssets + airdropAmount,
-            "assets mismatch"
-        );
     }
 }

--- a/src/test/AccountantProxy.t.sol
+++ b/src/test/AccountantProxy.t.sol
@@ -215,13 +215,6 @@ contract AccountantProxyTest is Setup {
         );
     }
 
-    function test_receiveReverts() public {
-        // Test that the contract reverts on ETH transfers
-        vm.deal(address(this), 1 ether);
-        vm.expectRevert("No ETH accepted");
-        payable(address(accountantProxy)).transfer(1 ether);
-    }
-
     function test_reportOnSelf_withFuzzedAmount(uint256 _amount) public {
         vm.assume(_amount > minFuzzAmount && _amount < maxFuzzAmount);
 


### PR DESCRIPTION
## Summary
- Adds AccountantProxy contract that wraps the existing Accountant to enable controlled self-reporting
- Allows authorized addresses to trigger vault self-reporting for capturing airdropped tokens
- Implements comprehensive sanity checks to ensure safety during self-reporting

## Key Features
- `reportOnSelf(vault)` function for authorized reporters to trigger vault self-reporting
- Sanity checks ensure PPS doesn't change and assets are properly accounted
- Pass-through fallback mechanism for all other accountant functions with governance validation
- Reporter management system with `setReporter()` function
- Inherits from Governance contract for ownership management

## Test Plan
- [x] Test reporter authorization management
- [x] Test successful self-reporting with airdropped tokens
- [x] Test revert conditions (no gain, unauthorized caller)
- [x] Test fallback forwarding with governance checks
- [x] Test governance transfer functionality
- [x] Test multiple reporters
- [x] Fuzz testing for various amounts

🤖 Generated with [Claude Code](https://claude.ai/code)